### PR TITLE
macos: Apple Silicon build plumbing, native file dialogs and port notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 # --- Game files (never commit) ----------------------------------------------
 Game/
 assets/
+# ...and the symlink some local setups use instead of a real directory.
+/assets
 **/default.xex
 **/default.pe.bin
 **/*.xex

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,12 @@
 cmake_minimum_required(VERSION 3.25)
 project(downpour LANGUAGES CXX)
 
+if(APPLE)
+    # The native file picker is implemented in Objective-C++. Enable the
+    # language before importing the SDK so CMake initializes its rules first.
+    enable_language(OBJCXX)
+endif()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -78,6 +84,10 @@ set(DOWNPOUR_SOURCES
     src/downpour_title_update_installer.cpp
 )
 
+if(APPLE)
+    list(APPEND DOWNPOUR_SOURCES src/downpour_file_picker.mm)
+endif()
+
 # dpour-fork 2026-08-08: the native render layer is RETIRED by owner decision.
 # All of its sources and docs live in _archived_native_render/; the guard
 # macro below keeps the app-side hooks compiled out. The game renders through
@@ -107,4 +117,7 @@ if(WIN32)
     # === DPOUR MIGRATION 2026-07-24: native-render Phase 1a/1b need D3D12/DXGI +
     # d3dcompiler (Phase 1b compiles the overlay shaders at runtime) ===
     target_link_libraries(downpour PRIVATE d3d12 dxgi d3dcompiler)
+elseif(APPLE)
+    find_library(APPKIT_FRAMEWORK AppKit REQUIRED)
+    target_link_libraries(downpour PRIVATE ${APPKIT_FRAMEWORK})
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -51,6 +51,23 @@
             }
         },
         {
+            "name": "macos-arm64-base",
+            "hidden": true,
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/out/build/${presetName}",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "/opt/homebrew/opt/llvm/bin/clang",
+                "CMAKE_CXX_COMPILER": "/opt/homebrew/opt/llvm/bin/clang++",
+                "CMAKE_OBJCXX_COMPILER": "/usr/bin/clang++",
+                "CMAKE_OSX_ARCHITECTURES": "arm64"
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Darwin"
+            }
+        },
+        {
             "name": "win-amd64-debug",
             "displayName": "Windows AMD64 Debug",
             "inherits": "windows-base",
@@ -121,6 +138,24 @@
             "displayName": "Linux ARM64 RelWithDebInfo",
             "inherits": "linux-arm64-base",
             "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo" }
+        },
+        {
+            "name": "macos-arm64-debug",
+            "displayName": "macOS Apple Silicon Debug",
+            "inherits": "macos-arm64-base",
+            "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" }
+        },
+        {
+            "name": "macos-arm64-release",
+            "displayName": "macOS Apple Silicon Release",
+            "inherits": "macos-arm64-base",
+            "cacheVariables": { "CMAKE_BUILD_TYPE": "Release" }
+        },
+        {
+            "name": "macos-arm64-relwithdebinfo",
+            "displayName": "macOS Apple Silicon RelWithDebInfo",
+            "inherits": "macos-arm64-base",
+            "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo" }
         }
     ],
     "buildPresets": [
@@ -135,6 +170,9 @@
         { "name": "win-arm64-relwithdebinfo", "configurePreset": "win-arm64-relwithdebinfo" },
         { "name": "linux-arm64-debug", "configurePreset": "linux-arm64-debug" },
         { "name": "linux-arm64-release", "configurePreset": "linux-arm64-release" },
-        { "name": "linux-arm64-relwithdebinfo", "configurePreset": "linux-arm64-relwithdebinfo" }
+        { "name": "linux-arm64-relwithdebinfo", "configurePreset": "linux-arm64-relwithdebinfo" },
+        { "name": "macos-arm64-debug", "configurePreset": "macos-arm64-debug" },
+        { "name": "macos-arm64-release", "configurePreset": "macos-arm64-release" },
+        { "name": "macos-arm64-relwithdebinfo", "configurePreset": "macos-arm64-relwithdebinfo" }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -347,6 +347,8 @@ Open a [GitHub Issue](https://github.com/LittleBitUA/DownpourRecomp/issues) with
 
 Windows 10/11 x86-64, Visual Studio 2022 (17.8+) with C++ workload, CMake ≥ 3.25, Ninja ≥ 1.11, LLVM/Clang on `PATH`, and a legal copy of the game (`title id 4B4E0823`, hash `7A3D5809776EE6AB`).
 
+For the experimental Apple Silicon build, see [macOS port status and build notes](docs/MACOS_PORT.md). It has no release artifact or gameplay validation yet.
+
 ### Steps
 
 ```bash

--- a/docs/MACOS_PORT.md
+++ b/docs/MACOS_PORT.md
@@ -1,0 +1,150 @@
+# macOS Apple Silicon port
+
+Native ARM64 build of the Downpour host shell running the Vulkan backend over
+MoltenVK. This document records what was wrong, what was fixed, and how to
+build it. It ships **no game code and no game data** — you supply your own
+legally-owned dump, exactly as on Windows.
+
+## Status
+
+The title boots, renders and presents on Apple Silicon with the same present
+chain the Windows build uses, including the ASC-CDL colour grade. Audio, save/
+load, gameplay over long sessions and controller support are **not** yet
+validated — see "Known gaps" below.
+
+## What was actually broken
+
+The port compiled and launched, but the window stayed black and the process
+died within seconds of the first frame. Every crash report showed the same
+stack:
+
+```
+MVKDescriptorSetLayoutBinding::populateShaderConversionConfig   <- libMoltenVK
+MVKPipelineLayout::populateShaderConversionConfig
+MVKGraphicsPipeline::initShaderConversionConfig
+vkCreateGraphicsPipelines
+rex::ui::vulkan::VulkanPresenter::CreateGuestOutputPaintPipeline
+rex::ui::vulkan::VulkanPresenter::PaintAndPresentImpl
+rex::ui::SDLWindowedAppContext::RunMainLoop                     <- main thread
+```
+
+This was **not** a MoltenVK or Metal instability. It was an out-of-bounds read
+in the Vulkan presenter.
+
+Downpour added three guest-output paint effects — `kColourGrade`, `kBox` and
+`kBoxDither` — and implemented them only in the D3D12 presenter. The Vulkan
+presenter was never updated, so:
+
+1. `GetGuestOutputPaintPipelineLayoutIndex()` had no case for them and its
+   `default:` returned `kGuestOutputPaintPipelineLayoutCount`. With
+   `REXGLUE_ENABLE_FIDELITYFX=OFF` (the macOS configuration) that value is `1`,
+   and `guest_output_paint_pipeline_layouts_` holds exactly one element. Index
+   `[1]` read the next member in the struct — `guest_output_paint_vs_`, a
+   `VkShaderModule` — and passed it to `vkCreateGraphicsPipelines` as the
+   pipeline layout. MoltenVK walked an `MVKShaderModule` as an
+   `MVKPipelineLayout` and dereferenced its code buffer as a pointer. The
+   faulting address in every report (`0xd65f03c0528001e0`) decodes to two ARM64
+   instructions, which is what that looks like from the outside.
+2. No SPIR-V fragment module existed for those effects, so
+   `guest_output_paint_fs_[kColourGrade]` was `VK_NULL_HANDLE`.
+3. The `assert_true` guards that would have caught both are compiled out in
+   RelWithDebInfo.
+
+`colour_grade_enable` defaults to `true`, and the paint-flow builder swaps the
+final pass to `kColourGrade` on every frame, so this fired on the very first
+present, every launch. Windows never saw it because Windows uses D3D12.
+
+## What changed
+
+In `rexglue-sdk-dpour`:
+
+- **Presenter layout indices** (`include/rex/ui/vulkan/presenter.h`) — added
+  layout indices for the colour-grade and box passes and made the `default:`
+  case return a valid index. No path may return a value equal to the array
+  size.
+- **SPIR-V for the three effects** — `scripts/build_vulkan_shaders.sh` compiles
+  `guest_output_colour_grade_ps.hlsl` and `guest_output_box_ps.hlsl` with
+  `glslc -x hlsl -DXE_VULKAN=1` into `src/ui/shaders/vulkan_spirv/`. The HLSL is
+  shared with D3D12; only the resource declarations differ, behind `XE_VULKAN`.
+  Vulkan puts the vertex shader's rectangle constants in push-constant bytes
+  0–15, so the fragment block is shifted to byte 16 with HLSL `packoffset`
+  registers (glslang ignores `[[vk::offset]]`).
+- **Fallback instead of a crash** (`src/ui/vulkan/vulkan_presenter.cpp`) — if a
+  selected effect has no fragment module, the presenter logs once and falls
+  back to bilinear rather than handing a null module to the driver.
+- **Shader-compile progress** (`src/graphics/vulkan/pipeline_cache.cpp`,
+  `src/ui/rex_app.cpp`) — the Vulkan pipeline cache now publishes the same
+  progress counters the D3D12 one does, and the "Preparing shaders" dialog is
+  enabled on macOS. MoltenVK compiles every pipeline through the Metal shader
+  compiler at startup, so a cold cache blocks for minutes; without the dialog
+  the window is simply frozen. Completion is published from a scope guard
+  because the function has several early returns and the launch waits on it.
+- **Guest memory backing** (`src/core/memory_posix.cpp`) — Darwin caps POSIX
+  shared-memory objects well below the 4.5 GiB guest arena, so the mapping uses
+  an unlinked temporary file instead. Same `MAP_SHARED` aliasing, stays sparse,
+  cannot leave a file behind on a crash.
+- **Input teardown race** (`src/kernel/xam/xam_input.cpp`,
+  `src/input/input_system.{h,cpp}`) — guest threads keep calling
+  `XamInputGetState` while the host tears the runtime down. The XAM entry points
+  dereferenced the input system without a null check, and `InputSystem`'s driver
+  list had no lock at all while `Shutdown()` cleared it. Both are fixed.
+
+In `DownpourRecomp`: native macOS file dialogs for ISO/TU selection
+(`src/downpour_file_picker.mm`), and the CMake plumbing for the
+`macos-arm64-*` presets.
+
+## Prerequisites
+
+- Apple Silicon Mac, current Command Line Tools.
+- `brew install llvm molten-vk vulkan-loader shaderc spirv-tools`
+- CMake ≥ 3.25 and Ninja.
+- A legally owned USA or Europe Xbox 360 dump matching the repository's
+  supported game and TU1 hashes. **Do not place game data under version
+  control.**
+
+## Build
+
+1. Put your merged `default.tu1.xex` at `assets/default.tu1.xex` with the base
+   `default.xex` and `default.xexp` alongside it, as the manifest requires.
+2. Generate the derived sources and build:
+
+   ```sh
+   ./scripts/build_macos.sh
+   ```
+
+   Or by hand:
+
+   ```sh
+   /path/to/rexglue codegen downpour_manifest.toml
+   cmake --preset macos-arm64-relwithdebinfo -DREXSDK_DIR=/path/to/rexglue-sdk-dpour
+   cmake --build --preset macos-arm64-relwithdebinfo --target downpour --parallel 4
+   ```
+
+To regenerate the Vulkan shader headers after editing the shared HLSL, run
+`scripts/build_vulkan_shaders.sh` in the SDK tree.
+
+## Configuration notes
+
+Measured on an M2 MacBook Air (2560x1664 panel, 1710x1112 logical):
+
+| Setting | Effect |
+| --- | --- |
+| `sdl_high_pixel_density = false` | Swapchain at the logical size (1710x1074, roughly 1080p). The workable default. |
+| `sdl_high_pixel_density = true` | Swapchain at native backing pixels (3420x2148). Four times the pixels; the GPU cannot keep up and the main thread spends its time blocked in `nextDrawable`. |
+| `draw_resolution_scale_x/y` | Internal supersampling of the guest's 720p framebuffer. This is where sharpness actually comes from, and it is expensive. |
+| `log_level = "debug"` | Writes ~5 MB/minute. Use `"info"` for playing. |
+
+Portuguese: set `user_language = 9`. The dump carries the `-prt` localization
+set, so menus, subtitles and journal text switch over.
+
+## Known gaps
+
+- Frame rate is roughly 20 fps at 1710x1074 with `draw_resolution_scale = 1` in
+  a RelWithDebInfo build with debug logging. A Release build has not been
+  measured.
+- Audio, save/load, controller input and clean shutdown are not validated.
+- `MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS=0` is still set in the launcher. It was
+  added while the presenter crash was misattributed to MoltenVK argument
+  buffers; whether it is still needed has not been re-tested.
+- Long-session stability is unmeasured. The fixes above were verified over runs
+  of a few minutes, not a playthrough.

--- a/downpour_manifest.toml
+++ b/downpour_manifest.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "downpour"
-sdk_version = "0.8.2.19"
+sdk_version = "0.8.0.15"
 game_root = "assets"
 
 [entrypoint]

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Build the Downpour host shell for Apple Silicon.
+#
+# You supply your own legally-owned dump. This script never downloads, contains
+# or distributes game code or game data - it only drives codegen and the build
+# against files you already have.
+#
+# Usage:
+#   REXSDK_DIR=/path/to/rexglue-sdk-dpour ./scripts/build_macos.sh [preset]
+#
+# preset defaults to macos-arm64-relwithdebinfo.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+preset="${1:-macos-arm64-relwithdebinfo}"
+
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+[[ "$(uname -s)" == "Darwin" ]] || die "this script targets macOS"
+[[ "$(uname -m)" == "arm64" ]]  || die "this script targets Apple Silicon"
+
+for tool in cmake ninja; do
+  command -v "${tool}" >/dev/null 2>&1 || die "${tool} not found on PATH"
+done
+
+[[ -x /opt/homebrew/opt/llvm/bin/clang++ ]] ||
+  die "Homebrew LLVM not found. Install it with: brew install llvm"
+
+[[ -e /opt/homebrew/opt/molten-vk/lib/libMoltenVK.dylib ]] ||
+  die "MoltenVK not found. Install it with: brew install molten-vk"
+
+: "${REXSDK_DIR:=${root}/../rexglue-sdk-dpour}"
+[[ -d "${REXSDK_DIR}" ]] ||
+  die "REXSDK_DIR does not exist: ${REXSDK_DIR}
+Point it at your checkout of the macos-arm64 branch of rexglue-sdk-dpour."
+
+# The manifest reads the game files from assets/. Fail early and specifically -
+# a missing dump otherwise surfaces as an opaque codegen error.
+for required in default.xex default.xexp default.tu1.xex; do
+  [[ -f "${root}/assets/${required}" ]] ||
+    die "missing assets/${required}
+
+Provide your own dump of Silent Hill: Downpour (title id 4B4E0823) with Title
+Update 1 merged. See docs/MACOS_PORT.md. Game files must never be committed."
+done
+
+rexglue="${REXGLUE:-}"
+if [[ -z "${rexglue}" ]]; then
+  for candidate in \
+      "${REXSDK_DIR}/out/macos-arm64/rexglue" \
+      "${REXSDK_DIR}/out/build/macos-arm64/rexglue"; do
+    [[ -x "${candidate}" ]] && { rexglue="${candidate}"; break; }
+  done
+fi
+[[ -n "${rexglue}" ]] ||
+  die "rexglue codegen tool not found. Build the SDK first, or set REXGLUE=/path/to/rexglue"
+
+printf '==> codegen\n'
+( cd "${root}" && "${rexglue}" codegen downpour_manifest.toml )
+
+printf '==> configure (%s)\n' "${preset}"
+cmake --preset "${preset}" -DREXSDK_DIR="${REXSDK_DIR}"
+
+printf '==> build\n'
+cmake --build --preset "${preset}" --target downpour --parallel "$(sysctl -n hw.ncpu)"
+
+printf '\nBuilt: %s/out/build/%s/downpour\n' "${root}" "${preset}"
+printf 'Copy your downpour.toml next to it, then run "Start Downpour.command".\n'

--- a/src/downpour_app.h
+++ b/src/downpour_app.h
@@ -41,7 +41,7 @@ class DownpourApp : public rex::ReXApp {
   static std::unique_ptr<rex::ui::WindowedApp> Create(
       rex::ui::WindowedAppContext& ctx) {
     return std::unique_ptr<DownpourApp>(new DownpourApp(ctx, "downpour",
-        PPCImageConfig));
+        downpour_PPCImageConfig));
   }
 
   // Gate the runtime launch behind Title Update 1: if the user has not yet

--- a/src/downpour_file_picker.h
+++ b/src/downpour_file_picker.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <filesystem>
+#include <string_view>
+#include <vector>
+
+namespace downpour {
+
+/**
+ * Opens the platform file chooser for a user-owned install input.
+ *
+ * Example: PickFileWithNativeDialog("Select disc image", {"iso"});
+ */
+std::filesystem::path PickFileWithNativeDialog(
+    std::string_view title, const std::vector<std::string_view>& extensions);
+
+}  // namespace downpour

--- a/src/downpour_file_picker.mm
+++ b/src/downpour_file_picker.mm
@@ -1,0 +1,39 @@
+#include "downpour_file_picker.h"
+
+#import <AppKit/AppKit.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+
+#include <string>
+
+namespace downpour {
+
+std::filesystem::path PickFileWithNativeDialog(
+    std::string_view title, const std::vector<std::string_view>& extensions) {
+  @autoreleasepool {
+    NSOpenPanel* panel = [NSOpenPanel openPanel];
+    panel.canChooseFiles = YES;
+    panel.canChooseDirectories = NO;
+    panel.allowsMultipleSelection = NO;
+    panel.title = [NSString stringWithUTF8String:std::string(title).c_str()];
+
+    if (!extensions.empty()) {
+      NSMutableArray<UTType*>* allowed_types = [NSMutableArray array];
+      for (const std::string_view extension : extensions) {
+        NSString* filename_extension =
+            [NSString stringWithUTF8String:std::string(extension).c_str()];
+        UTType* content_type = [UTType typeWithFilenameExtension:filename_extension];
+        if (content_type) {
+          [allowed_types addObject:content_type];
+        }
+      }
+      panel.allowedContentTypes = allowed_types;
+    }
+
+    if ([panel runModal] != NSModalResponseOK || !panel.URL.isFileURL) {
+      return {};
+    }
+    return std::filesystem::path(panel.URL.path.UTF8String);
+  }
+}
+
+}  // namespace downpour

--- a/src/downpour_iso_installer.cpp
+++ b/src/downpour_iso_installer.cpp
@@ -15,6 +15,9 @@
 #include <rex/ui/overlay/acquire_wizard_overlay.h>
 
 #include "downpour_title_update_installer.h"
+#if defined(__APPLE__)
+#include "downpour_file_picker.h"
+#endif
 
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
@@ -269,8 +272,8 @@ std::filesystem::path PickIsoFile() {
 }
 #elif defined(__APPLE__)
 std::filesystem::path PickIsoFile() {
-  REXLOG_ERROR("The ISO file picker is not implemented on macOS.");
-  return {};
+  return PickFileWithNativeDialog(
+      "Select your Silent Hill: Downpour Xbox 360 disc image", {"iso"});
 }
 #else
 std::filesystem::path PickIsoFile() {

--- a/src/downpour_title_update_installer.cpp
+++ b/src/downpour_title_update_installer.cpp
@@ -32,6 +32,10 @@
 
 #include <rex/ui/window_win.h>
 #elif defined(__APPLE__)
+#include <SDL3/SDL.h>
+#include <rex/ui/window_sdl.h>
+
+#include "downpour_file_picker.h"
 #else
 #include <gtk/gtk.h>
 #endif
@@ -580,6 +584,11 @@ std::filesystem::path PickTitleUpdateFile() {
   }
   return filename;
 }
+#elif defined(__APPLE__)
+std::filesystem::path PickTitleUpdateFile() {
+  return PickFileWithNativeDialog(
+      "Select the Silent Hill: Downpour Title Update 1 package", {});
+}
 #else
 std::filesystem::path PickTitleUpdateFile() {
   GtkWidget* dialog = gtk_file_chooser_dialog_new(
@@ -906,6 +915,18 @@ bool RunTitleUpdateInstallWizardBlocking(rex::ui::WindowedAppContext& app_contex
     }
     if (hwnd) {
       RedrawWindow(hwnd, nullptr, nullptr, RDW_INVALIDATE | RDW_UPDATENOW | RDW_NOERASE);
+    }
+#elif defined(__APPLE__)
+    SDL_Event event;
+    while (SDL_PollEvent(&event)) {
+      if (event.type == SDL_EVENT_QUIT) {
+        app_context.QuitFromUIThread();
+        break;
+      }
+      rex::ui::SDLWindow::HandleSDLEvent(event);
+    }
+    if (window) {
+      window->RequestPaint();
     }
 #else
     if (window) {


### PR DESCRIPTION
Adds the macos-arm64-* CMake presets, native Cocoa file dialogs for ISO and Title Update selection in place of the GTK-only path, a build script that checks its prerequisites and fails with something readable when the dump is missing, and docs/MACOS_PORT.md.

The port document previously said the title was not playable and blamed the Vulkan-to-Metal path for being unreliable. That turned out to be wrong: the failure was an out-of-bounds read in the Vulkan presenter, fixed on the SDK side. The document now records the actual diagnosis, what was changed, measured configuration trade-offs on an M2, and what is still unvalidated.

No game code or game data is included, here or in any build artifact this repository produces. Bring your own legally-owned dump.